### PR TITLE
Issue 9 authenticated api calls

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,7 @@ export default class App extends Mixins(ServiceWorkerMixin) {
     this.refreshApplication()
   }
 
-  mounted () {
+  mounted() {
     Analytics.logEvent(Analytics.AnalyticsEventType.APP, 'load', 'page')
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -47,7 +47,7 @@
 import { Component, Mixins } from 'vue-property-decorator'
 import ServiceWorkerMixin from '@/mixins/ServiceWorkerMixin'
 import Button from '@/components/common/Button.vue'
-import logEvent, { AnalyticsEventType } from '@/utils/Analytics'
+import * as Analytics from '@/utils/Analytics'
 
 @Component({
   name: 'App',
@@ -60,8 +60,8 @@ export default class App extends Mixins(ServiceWorkerMixin) {
     this.refreshApplication()
   }
 
-  mounted() {
-    logEvent(AnalyticsEventType.APP, 'load', 'page')
+  mounted () {
+    Analytics.logEvent(Analytics.AnalyticsEventType.APP, 'load', 'page')
   }
 }
 </script>

--- a/src/components/common/Button.vue
+++ b/src/components/common/Button.vue
@@ -12,9 +12,14 @@ import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
 
 export enum Type {
   PRIMARY = 'primary',
-  SECONDARY = 'secondary',
+  SECONDARY = 'secondary'
+}
+
+export enum Size {
+  NORMAL = 'normal',
   HUGE = 'huge'
 }
+
 @Component({
   components: {
   }
@@ -22,6 +27,7 @@ export enum Type {
 export default class Button extends Vue {
   @Prop() private label!: string
   @Prop({ default: Type.PRIMARY }) readonly type!: Type
+  @Prop({ default: Size.NORMAL }) readonly size!: Size
 
   @Emit('click')
   onClick() {
@@ -29,7 +35,7 @@ export default class Button extends Vue {
   }
 
   get buttonClass(): string {
-    return `type-${this.type}`
+    return `type-${this.type} size-${this.size}`
   }
 }
 </script>
@@ -39,10 +45,11 @@ button {
   border-radius: 10px;
 }
 
-button.type-huge {
-  background-color: #e2c7ec;
-  border: 1px solid #977ca1;
-  color: #000;
+button.size-normal {
+  padding: 9px;
+}
+
+button.size-huge {
   padding: 14px;
   font-size: 100%;
 }
@@ -51,13 +58,11 @@ button.type-primary {
   background-color: #e2c7ec;
   border: 1px solid #977ca1;
   color: #000;
-  padding: 9px;
 }
 
 button.type-secondary {
   background-color: #fff;
   border: 1px solid #977ca1;
   color: #000;
-  padding: 9px;
 }
 </style>

--- a/src/components/common/Message.vue
+++ b/src/components/common/Message.vue
@@ -64,6 +64,12 @@ export default class Message extends Vue {
 
 .header {
     font-weight: bold;
-    margin: 0 0 10px 0;
+}
+
+.message-container div {
+    margin: 10px 0 0 0;
+}
+.message-container div:first-child {
+    margin: 0 0 0 0;
 }
 </style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -46,7 +46,7 @@ router.beforeEach((to, from, next) => {
     const newPath = to.fullPath.replace('/' + to.params.id, '')
     next({
       path: '/auth',
-      query: {newPath, id},
+      query: { newPath, id }
     })
   } else {
     next()

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,12 +6,7 @@ Vue.use(VueRouter)
 
 const routes: Array<RouteConfig> = [
   {
-    path: '/',
-    name: 'Home',
-    component: Home
-  },
-  {
-    path: '/about',
+    path: '/:id?/about',
     name: 'About',
     // route level code-splitting
     // this generates a separate chunk (about.[hash].js) for this route
@@ -19,17 +14,43 @@ const routes: Array<RouteConfig> = [
     component: () => import(/* webpackChunkName: "about" */ '../views/About.vue')
   },
   {
-    path: '/devicetest',
+    path: '/:id?/devicetest',
     name: 'DeviceTest',
     // route level code-splitting
     // this generates a separate chunk (devicetest.[hash].js) for this route
     // which is lazy-loaded when the route is visited.
     component: () => import(/* webpackChunkName: "devicetest" */ '../views/DeviceTest.vue')
+  },
+  {
+    path: '/auth',
+    name: 'Auth',
+    // route level code-splitting
+    // this generates a separate chunk (devicetest.[hash].js) for this route
+    // which is lazy-loaded when the route is visited.
+    component: () => import(/* webpackChunkName: "auth" */ '../views/Auth.vue')
+  },
+  {
+    path: '/:id?',
+    name: 'Home',
+    component: Home
   }
 ]
 
 const router = new VueRouter({
   routes
+})
+
+router.beforeEach((to, from, next) => {
+  const id = to.params?.id
+  if (id) {
+    const newPath = to.fullPath.replace('/' + to.params.id, '')
+    next({
+      path: '/auth',
+      query: {newPath, id},
+    })
+  } else {
+    next()
+  }
 })
 
 export default router

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,4 @@
-import logEvent, { AnalyticsEventType } from '@/utils/Analytics'
+import * as Analytics from '@/utils/Analytics'
 
 export enum Status {
   PENDING,
@@ -9,6 +9,7 @@ export enum Status {
 
 type DeviceTestStatus = {
   status: Status
+  statusMessage?: string
 }
 
 type State = {
@@ -29,13 +30,14 @@ const state: State = {
 
 const store = {
   state,
-  setDeviceTestStatus(testName: string, status: Status) {
-    console.log(`Set status for ${testName} to ${status}. `)
-    logEvent(AnalyticsEventType.DEVICE_TEST, 'set', 'status', {
+  setDeviceTestStatus(testName: string, status: Status, message?: string) {
+    console.log(`Set status for ${testName} to ${status} with message '${message}'.`)
+    Analytics.logEvent(Analytics.AnalyticsEventType.DEVICE_TEST, 'set', 'status', {
       test: testName,
       status: Status[status]
     })
     this.state.deviceTest[testName].status = status
+    this.state.deviceTest[testName].statusMessage = message
   }
 }
 

--- a/src/utils/Analytics.ts
+++ b/src/utils/Analytics.ts
@@ -16,7 +16,23 @@ const initAmplitude = () => {
   isAnalyticsInitialized = true
 }
 
-export default (type: AnalyticsEventType, eventVerb: string, eventObject: string, props?: Record<string, any>) => {
+export type UserProperties = {
+  group_key?: string
+  group_name?: string
+  user_key?: string
+  competition_key?: string
+}
+
+export const setUserProperties = (props: UserProperties) => {
+  const identify = new amplitude.Identify()
+    .set('competitionKey', props.competition_key || '')
+    .set('groupKey', props.group_key || '')
+    .set('groupName', props.group_name || '')
+    .set('userKey', props.user_key || '')
+  amplitude.getInstance().identify(identify);
+}
+
+export const logEvent = (type: AnalyticsEventType, eventVerb: string, eventObject: string, props?: Record<string, any>) => {
   const actionName = eventVerb.toLowerCase() + ' ' + eventObject.toLowerCase()
   const eventName = AnalyticsEventType[type].toLowerCase() + ': ' + actionName
   const patchedProps = {

--- a/src/utils/Analytics.ts
+++ b/src/utils/Analytics.ts
@@ -29,7 +29,7 @@ export const setUserProperties = (props: UserProperties) => {
     .set('groupKey', props.group_key || '')
     .set('groupName', props.group_name || '')
     .set('userKey', props.user_key || '')
-  amplitude.getInstance().identify(identify);
+  amplitude.getInstance().identify(identify)
 }
 
 export const logEvent = (type: AnalyticsEventType, eventVerb: string, eventObject: string, props?: Record<string, any>) => {

--- a/src/utils/Auth.ts
+++ b/src/utils/Auth.ts
@@ -1,20 +1,20 @@
 const TOKEN_COOKIE_NAME = 'tunnelbanejakten-api.token'
 
 export const setTokenCookie = (token: string) => {
-    document.cookie = `${TOKEN_COOKIE_NAME}=${token};max-age=${7 * 24 * 60 * 60};samesite;secure`
+  document.cookie = `${TOKEN_COOKIE_NAME}=${token};max-age=${7 * 24 * 60 * 60};samesite;secure`
 }
 
 export const unsetTokenCookie = () => {
-    document.cookie = `${TOKEN_COOKIE_NAME}=;max-age=0;expires=0;samesite;secure`
+  document.cookie = `${TOKEN_COOKIE_NAME}=;max-age=0;expires=0;samesite;secure`
 }
 
 export const getTokenCookie = (): string | null => {
-    const cookies: string[] = document.cookie.split('; ')
-    const cookie = cookies.find((c: string) => c.startsWith(TOKEN_COOKIE_NAME + '='))
-    if (cookie) {
-        const cookieValue = cookie.split('=')[1];
-        return cookieValue || null
-    } else {
-        return null
-    }
+  const cookies: string[] = document.cookie.split('; ')
+  const cookie = cookies.find((c: string) => c.startsWith(TOKEN_COOKIE_NAME + '='))
+  if (cookie) {
+    const cookieValue = cookie.split('=')[1]
+    return cookieValue || null
+  } else {
+    return null
+  }
 }

--- a/src/utils/Auth.ts
+++ b/src/utils/Auth.ts
@@ -1,0 +1,20 @@
+const TOKEN_COOKIE_NAME = 'tunnelbanejakten-api.token'
+
+export const setTokenCookie = (token: string) => {
+    document.cookie = `${TOKEN_COOKIE_NAME}=${token};max-age=${7 * 24 * 60 * 60};samesite;secure`
+}
+
+export const unsetTokenCookie = () => {
+    document.cookie = `${TOKEN_COOKIE_NAME}=;max-age=0;expires=0;samesite;secure`
+}
+
+export const getTokenCookie = (): string | null => {
+    const cookies: string[] = document.cookie.split('; ')
+    const cookie = cookies.find((c: string) => c.startsWith(TOKEN_COOKIE_NAME + '='))
+    if (cookie) {
+        const cookieValue = cookie.split('=')[1];
+        return cookieValue || null
+    } else {
+        return null
+    }
+}

--- a/src/views/Auth.vue
+++ b/src/views/Auth.vue
@@ -1,0 +1,105 @@
+<template>
+  <Page title="Logga in">
+    <h2>Logga in</h2>
+    <p>{{ authStatus }}</p>
+  </Page>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from "vue-property-decorator";
+import Page from "@/components/layout/Page.vue";
+import * as AuthUtils from "@/utils/Auth";
+import * as Analytics from "@/utils/Analytics";
+
+const apiHost = process.env.VUE_APP_API_HOST;
+
+enum GetTokenStatus {
+  NOT_STARTED,
+  PENDING,
+  SUCCESS,
+  FAILURE,
+}
+
+@Component({
+  components: {
+    Page,
+  },
+})
+export default class Auth extends Vue {
+  private tokenStatus: GetTokenStatus = GetTokenStatus.NOT_STARTED;
+
+  get authStatus(): string {
+    switch (this.tokenStatus) {
+      case GetTokenStatus.NOT_STARTED:
+        return "NOT_STARTED";
+      case GetTokenStatus.PENDING:
+        return "Loggar in...";
+      case GetTokenStatus.SUCCESS:
+        return "Inloggningen gick bra.";
+      case GetTokenStatus.FAILURE:
+        return "Något gick fel.";
+      default:
+        return "UNKNOWN";
+    }
+  }
+
+  get nextRoute(): string {
+    return String(this.$route.query.newPath);
+  }
+
+  setToken(token: string | null) {
+    if (token) {
+      AuthUtils.setTokenCookie(token);
+    } else {
+      AuthUtils.unsetTokenCookie();
+    }
+  }
+
+  async logIn(id: string) {
+    try {
+      this.tokenStatus = GetTokenStatus.PENDING;
+      const resp = await fetch(`${apiHost}/wp-json/tuja/v1/tokens`, {
+        method: "POST",
+        body: JSON.stringify({ id }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      if (resp.ok) {
+        const payload = await resp.json();
+        this.setToken(payload.token);
+        this.tokenStatus = GetTokenStatus.SUCCESS;
+
+        const token = AuthUtils.getTokenCookie();
+        if (token) {
+          const profileResp = await fetch(
+            `${apiHost}/wp-json/tuja/v1/profile?token=${token}`
+          );
+          if (profileResp.ok) {
+            const profilePayload = await profileResp.json();
+            Analytics.setUserProperties({
+              group_key: profilePayload.key,
+              group_name: profilePayload.name,
+            });
+          }
+        }
+
+        if (this.nextRoute) {
+          await this.$router.push({ path: this.nextRoute });
+        }
+      } else {
+        this.setToken(null);
+        this.tokenStatus = GetTokenStatus.FAILURE;
+      }
+    } catch (e) {
+      this.tokenStatus = GetTokenStatus.FAILURE;
+    }
+  }
+
+  mounted() {
+    if (this.$route.query.id) {
+      this.logIn(String(this.$route.query.id));
+    }
+  }
+}
+</script>

--- a/src/views/Auth.vue
+++ b/src/views/Auth.vue
@@ -6,12 +6,12 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
-import Page from "@/components/layout/Page.vue";
-import * as AuthUtils from "@/utils/Auth";
-import * as Analytics from "@/utils/Analytics";
+import { Component, Vue } from 'vue-property-decorator'
+import Page from '@/components/layout/Page.vue'
+import * as AuthUtils from '@/utils/Auth'
+import * as Analytics from '@/utils/Analytics'
 
-const apiHost = process.env.VUE_APP_API_HOST;
+const apiHost = process.env.VUE_APP_API_HOST
 
 enum GetTokenStatus {
   NOT_STARTED,
@@ -22,8 +22,8 @@ enum GetTokenStatus {
 
 @Component({
   components: {
-    Page,
-  },
+    Page
+  }
 })
 export default class Auth extends Vue {
   private tokenStatus: GetTokenStatus = GetTokenStatus.NOT_STARTED;
@@ -31,74 +31,74 @@ export default class Auth extends Vue {
   get authStatus(): string {
     switch (this.tokenStatus) {
       case GetTokenStatus.NOT_STARTED:
-        return "NOT_STARTED";
+        return 'NOT_STARTED'
       case GetTokenStatus.PENDING:
-        return "Loggar in...";
+        return 'Loggar in...'
       case GetTokenStatus.SUCCESS:
-        return "Inloggningen gick bra.";
+        return 'Inloggningen gick bra.'
       case GetTokenStatus.FAILURE:
-        return "Något gick fel.";
+        return 'Något gick fel.'
       default:
-        return "UNKNOWN";
+        return 'UNKNOWN'
     }
   }
 
   get nextRoute(): string {
-    return String(this.$route.query.newPath);
+    return String(this.$route.query.newPath)
   }
 
   setToken(token: string | null) {
     if (token) {
-      AuthUtils.setTokenCookie(token);
+      AuthUtils.setTokenCookie(token)
     } else {
-      AuthUtils.unsetTokenCookie();
+      AuthUtils.unsetTokenCookie()
     }
   }
 
   async logIn(id: string) {
     try {
-      this.tokenStatus = GetTokenStatus.PENDING;
+      this.tokenStatus = GetTokenStatus.PENDING
       const resp = await fetch(`${apiHost}/wp-json/tuja/v1/tokens`, {
-        method: "POST",
+        method: 'POST',
         body: JSON.stringify({ id }),
         headers: {
-          "Content-Type": "application/json",
-        },
-      });
+          'Content-Type': 'application/json'
+        }
+      })
       if (resp.ok) {
-        const payload = await resp.json();
-        this.setToken(payload.token);
-        this.tokenStatus = GetTokenStatus.SUCCESS;
+        const payload = await resp.json()
+        this.setToken(payload.token)
+        this.tokenStatus = GetTokenStatus.SUCCESS
 
-        const token = AuthUtils.getTokenCookie();
+        const token = AuthUtils.getTokenCookie()
         if (token) {
           const profileResp = await fetch(
             `${apiHost}/wp-json/tuja/v1/profile?token=${token}`
-          );
+          )
           if (profileResp.ok) {
-            const profilePayload = await profileResp.json();
+            const profilePayload = await profileResp.json()
             Analytics.setUserProperties({
               group_key: profilePayload.key,
-              group_name: profilePayload.name,
-            });
+              group_name: profilePayload.name
+            })
           }
         }
 
         if (this.nextRoute) {
-          await this.$router.push({ path: this.nextRoute });
+          await this.$router.push({ path: this.nextRoute })
         }
       } else {
-        this.setToken(null);
-        this.tokenStatus = GetTokenStatus.FAILURE;
+        this.setToken(null)
+        this.tokenStatus = GetTokenStatus.FAILURE
       }
     } catch (e) {
-      this.tokenStatus = GetTokenStatus.FAILURE;
+      this.tokenStatus = GetTokenStatus.FAILURE
     }
   }
 
   mounted() {
     if (this.$route.query.id) {
-      this.logIn(String(this.$route.query.id));
+      this.logIn(String(this.$route.query.id))
     }
   }
 }

--- a/src/views/DeviceTest.vue
+++ b/src/views/DeviceTest.vue
@@ -4,22 +4,23 @@
       :current-index="currentIndex"
       :statuses="statuses"
     />
-    <Message
-      v-if="isStatusMessageAvailable"
-      :message="statusMessage"
-      :type="statusType"
-    />
     <div class="test-component-wrapper">
       <component
         :is="currentComponent()"
       />
     </div>
+    <Message
+      v-if="isStatusMessageAvailable"
+      :header="statusHeader"
+      :message="statusMessage"
+      :type="statusType"
+    />
     <div class="step-navigation">
       <div class="step-navigate-button">
         <Button
           v-if="isPreviousStepAvailable()"
           @click="previous"
-          label="Tillbaka"
+          label="Bakåt"
           type="secondary"
         />
       </div>
@@ -143,7 +144,7 @@ export default class DeviceTest extends Vue {
     }
   }
 
-  get statusMessage() {
+  get statusHeader() {
     switch (this.state[this.steps[this.currentIndex].stateKey]?.status) {
       case Status.SUCCESS:
         return 'Testet gick bra.'
@@ -152,6 +153,10 @@ export default class DeviceTest extends Vue {
       default:
         return 'Lite oklar status just nu...'
     }
+  }
+
+  get statusMessage() {
+    return this.state[this.steps[this.currentIndex].stateKey]?.statusMessage
   }
 
   stepCount() {

--- a/src/views/device-test/Camera.vue
+++ b/src/views/device-test/Camera.vue
@@ -2,8 +2,9 @@
   <div>
     <p>Flera uppgifter under tävlingen besvaras med foton.</p>
     <Button
-      label="Testa kamera"
-      type="huge"
+      :label="startTestButtonLabel"
+      :type="startTestButtonType"
+      size="huge"
       @click="onStartTest"
     />
     <Fullscreen v-if="isCameraShown">
@@ -59,6 +60,18 @@ export default class Camera extends Vue {
   private isCameraShown = false;
 
   private img? = '';
+
+  get startTestButtonLabel() {
+    return [Status.PENDING, Status.USER_INTERACTION_REQUIRED].includes(store.state.deviceTest.camera.status)
+      ? 'Testa kamera'
+      : 'Testa kamera igen'
+  }
+
+  get startTestButtonType() {
+    return [Status.PENDING, Status.USER_INTERACTION_REQUIRED].includes(store.state.deviceTest.camera.status)
+      ? 'primary'
+      : 'secondary'
+  }
 
   onStartTest() {
     this.isCameraShown = true

--- a/src/views/device-test/Location.vue
+++ b/src/views/device-test/Location.vue
@@ -5,9 +5,10 @@
       platser. Därför behöver vi få tillgång till din GPS.
     </p>
     <Button
-      label="Testa GPS"
       @click="onStartTest"
-      :type="!isPositioningSuccessful ? 'huge' : 'secondary'"
+      size="huge"
+      :label="startTestButtonLabel"
+      :type="startTestButtonType"
     />
     <Fullscreen v-if="isTestStarted">
       <div
@@ -106,6 +107,18 @@ export default class Location extends Vue {
   private isTestStarted = false;
   private testStatus: Status = Status.USER_INTERACTION_REQUIRED;
   private watchId = 0;
+
+  get startTestButtonLabel() {
+    return [Status.PENDING, Status.USER_INTERACTION_REQUIRED].includes(store.state.deviceTest.location.status)
+      ? 'Testa GPS'
+      : 'Testa GPS igen'
+  }
+
+  get startTestButtonType() {
+    return [Status.PENDING, Status.USER_INTERACTION_REQUIRED].includes(store.state.deviceTest.location.status)
+      ? 'primary'
+      : 'secondary'
+  }
 
   onStartTest() {
     this.isTestStarted = true

--- a/src/views/device-test/Location.vue
+++ b/src/views/device-test/Location.vue
@@ -63,7 +63,7 @@ import Fullscreen from '@/components/common/Fullscreen.vue'
 import ConfirmationOverlay from '@/components/common/ConfirmationOverlay.vue'
 import Map, { Marker } from '@/components/common/Map.vue'
 import store, { Status } from '@/store'
-import logEvent, { AnalyticsEventType } from '@/utils/Analytics'
+import * as Analytics from '@/utils/Analytics'
 
 const GeolocationStatus = {
   UNKNOWN: 'UNKNOWN',
@@ -171,7 +171,7 @@ export default class Location extends Vue {
         geolocationStatus === GeolocationStatus.LOCATION_REQUEST_SUCCEEDED
           ? { accuracy: this.currentPosition.accuracy }
           : {}
-      logEvent(AnalyticsEventType.LOCATION, 'set', 'status', {
+      Analytics.logEvent(Analytics.AnalyticsEventType.LOCATION, 'set', 'status', {
         status: geolocationStatus,
         ...additionalProps
       })


### PR DESCRIPTION
De mest intressanta bitarna i den här PR:en:

- router/index.ts: `router.beforeEach` fångar upp grupp-id från URL och dirigerar om användaren till Auth-vyn.
- views/Auth.vue: Loggar in användaren (via grupp-id) och sparar token i cookie.
- utils/Auth.ts: Ett par hjälpfunktioner för att läsa resp. skriva token till cookie.

Resten av ändringarna handlar mest om kosmetika och loggning.